### PR TITLE
Fixes precision rounding for Score Rank percentage

### DIFF
--- a/Counters+/Counters/ScoreCounter.cs
+++ b/Counters+/Counters/ScoreCounter.cs
@@ -67,7 +67,7 @@ namespace CountersPlus.Counters
         {
             if (GameObject.Find("RelativeScoreText") != null && !settings.UseOld) GameObject.Find("RelativeScoreText").transform.parent = transform;
             if (GameObject.Find("ScorePanel") != null && !settings.UseOld) Destroy(GameObject.Find("ScorePanel"));
-            roundMultiple = (float)Math.Pow(100, settings.DecimalPrecision);
+            roundMultiple = (float)Math.Pow(10, settings.DecimalPrecision + 2);
 
             _scoreMesh = this.gameObject.AddComponent<TextMeshPro>();
             _scoreMesh.text = "100.0%";


### PR DESCRIPTION
The current implementation only works for settings.DecimalPrecision = 2. 

For settings.DecimalPrecision = 1, it will always round off and truncate the tenths place since the roundMultiple = 100.

```
roundMultiple = 100 ^ precision 
              = 100 ^ 1 
              = 100
ratio = floor(ratio * roundMultiple) / roundMultiple 
      = floor(0.905 * 100) / 100 
      = floor(90.5) / 100 
      = 90 / 100
```

For settings.DecimalPrecision > 2, it will include too many decimal places when rounding down, since roundMultiple is increasing in the order of 100x, not 10x. 

The latter isn't noticed because ToString will truncate the extra decimal places. For the former, it is noticed because the tenths decimal place never updates.