### PR TITLE
Add option to display the average cut of both sabers separately

### DIFF
--- a/Counters+/UI/AdvancedCounterSettings.cs
+++ b/Counters+/UI/AdvancedCounterSettings.cs
@@ -167,7 +167,12 @@ namespace CountersPlus.UI
                     speedHover.text = DetermineModeText(CC.settings.speedConfig.Mode);
                 };
             } },
-            { CC.settings.cutConfig, (sub, config) => { } },
+            { CC.settings.cutConfig, (sub, config) => {
+                var label = CPEVC.AddList(ref sub, CC.settings.cutConfig, "Separate Saber Counts", "Shows the average cut for the left and right sabers separately", 2);
+                label.GetTextForValue = (v) => (v != 0f) ? "ON" : "OFF";
+                label.GetValue = () => CC.settings.cutConfig.SeparateSaberCounts ? 1f : 0f;
+                label.SetValue += (v) => CC.settings.cutConfig.SeparateSaberCounts = v != 0f;
+            } },
             { CC.settings.spinometerConfig, (sub, config) => {
                 var spinometerMode = CPEVC.AddList(ref sub, config, "Mode", "", spinometerSettings.Count());
                 spinometerMode.GetTextForValue = (v) => {

--- a/Counters+/UI/MockCounter.cs
+++ b/Counters+/UI/MockCounter.cs
@@ -135,7 +135,12 @@ namespace CountersPlus.UI
                         Create(settings, "Top Speed (5 Sec.)", $"{Math.Round(info.leftSpeedAverage + 10, (settings as SpeedConfigModel).DecimalPrecision)}");
                 }
                 else if (settings is CutConfigModel)
-                    Create(settings, "Average Cut", $"{Mathf.RoundToInt(info.averageCutScore)}");
+                {
+                    if ((settings as CutConfigModel).SeparateSaberCounts)
+                        Create(settings, "Average Cut", $"{Mathf.RoundToInt(info.averageCutScore) - 10}  {Mathf.RoundToInt(info.averageCutScore)}");
+                    else
+                        Create(settings, "Average Cut", $"{Mathf.RoundToInt(info.averageCutScore)}");
+                }
                 else if (settings is ProgressConfigModel)
                     Create(settings,
                                 $"{(settings as ProgressConfigModel).Mode.ToString()} Progress",

--- a/Counters+/Utils/Config.cs
+++ b/Counters+/Utils/Config.cs
@@ -174,6 +174,7 @@ namespace CountersPlus.Config
 
     public sealed class CutConfigModel : ConfigModel {
         public CutConfigModel() { DisplayName = "Cut"; VersionAdded = new SemVer.Version("1.1.0"); }
+        public bool SeparateSaberCounts;
     }
 
     public sealed class NotesLeftConfigModel : ConfigModel

--- a/Counters+/Utils/ConfigDefaults.cs
+++ b/Counters+/Utils/ConfigDefaults.cs
@@ -11,7 +11,7 @@ namespace CountersPlus.Config
             { "Progress", new ProgressConfigModel() { Enabled = true, Position = ICounterPositions.BelowEnergy, Distance = 0, Mode = ICounterMode.Original, ProgressTimeLeft = false, IncludeRing = false } },
             { "Score", new ScoreConfigModel() { Enabled = true, Position = ICounterPositions.BelowMultiplier, Distance = 0, DecimalPrecision = 2, DisplayRank = true, Mode = ICounterMode.Original } },
             { "Speed", new SpeedConfigModel() { Enabled = false, Position = ICounterPositions.BelowMultiplier, Distance = 1, DecimalPrecision = 2, Mode = ICounterMode.Average } },
-            { "Cut", new CutConfigModel() { Enabled = false, Position = ICounterPositions.AboveHighway, Distance = 0 } },
+            { "Cut", new CutConfigModel() { Enabled = false, Position = ICounterPositions.AboveHighway, Distance = 0, SeparateSaberCounts = false} },
             { "Spinometer", new SpinometerConfigModel() { Enabled = false, Position = ICounterPositions.AboveMultiplier, Distance = 0, Mode = ICounterMode.Highest } },
             { "Personal Best", new PBConfigModel() { Enabled = true, Position = ICounterPositions.BelowMultiplier, Distance = 1, DecimalPrecision = 2, TextSize = 2, UnderScore = true, HideFirstScore = false } },
             { "Notes Left", new NotesLeftConfigModel() { Enabled = false, Position = ICounterPositions.AboveHighway, Distance = -1, LabelAboveCount = false, } },


### PR DESCRIPTION
Adds a toggle to the "Cut" settings to show two averages next to each other. One for each saber.