### PR TITLE
+ Custom Rank Color option

### DIFF
--- a/Counters+/Counters/ScoreCounter.cs
+++ b/Counters+/Counters/ScoreCounter.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using TMPro;
 using CountersPlus.Config;
+using System;
 
 namespace CountersPlus.Counters
 {
@@ -10,8 +11,9 @@ namespace CountersPlus.Counters
         internal TMP_Text ScoreMesh;
         internal TMP_Text RankText;
         internal TMP_Text PointsText;
+        
+        private static ScoreConfigModel settings;
 
-        private ScoreConfigModel settings;
 
         GameObject _RankObject;
         int decimalPrecision;
@@ -70,7 +72,7 @@ namespace CountersPlus.Counters
             ScoreMesh.fontSize = 3;
             ScoreMesh.color = Color.white;
             ScoreMesh.alignment = TextAlignmentOptions.Center;
-
+                
             //transform.Find("ScoreText").GetComponent<TextMeshProUGUI>().rectTransform.position = position + new Vector3(-6.425f, 7.67f, 0);
             transform.Find("ScoreText").GetComponent<TextMeshProUGUI>().rectTransform.position = position + new Vector3(-0.01f, 7.77f, 0);
             if (settings.DisplayRank)
@@ -80,7 +82,13 @@ namespace CountersPlus.Counters
                 TextHelper.CreateText(out RankText, position);
                 RankText.text = "\nSS";
                 RankText.fontSize = 4;
-                RankText.color = Color.white;
+                if (!settings.CustomRankColors)
+                    RankText.color = Color.white; //if custom rank colors is disabled, just set color to white
+                if (settings.CustomRankColors)
+                {
+                    ColorUtility.TryParseHtmlString(settings.SSColor, out Color defaultColor);
+                    RankText.color = defaultColor;
+                }
                 RankText.alignment = TextAlignmentOptions.Center;
             }
             if (settings.Mode == ICounterMode.LeavePoints || settings.Mode == ICounterMode.BaseWithOutPoints)
@@ -90,5 +98,46 @@ namespace CountersPlus.Counters
             }
             GetComponent<ImmediateRankUIPanel>().Start(); //BS way of getting Harmony patch to function but "if it works its not stupid" ~Caeden117
         }
+        /*public void SetColor()
+        {
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "SS" | RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "SSS")
+            {
+                ColorUtility.TryParseHtmlString(settings.SSColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "S")
+            {
+                ColorUtility.TryParseHtmlString(settings.SColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "A")
+            {
+                ColorUtility.TryParseHtmlString(settings.AColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "B")
+            {
+                ColorUtility.TryParseHtmlString(settings.BColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "C")
+            {
+                ColorUtility.TryParseHtmlString(settings.CColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "D")
+            {
+                ColorUtility.TryParseHtmlString(settings.DColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "E")
+            {
+                ColorUtility.TryParseHtmlString(settings.EColor, out Color RankColor);
+                RankText.color = RankColor;
+            }
+            else
+                RankText.color = Color.white;
+            
+        }*/
     }
 }

--- a/Counters+/Counters/ScoreCounter.cs
+++ b/Counters+/Counters/ScoreCounter.cs
@@ -2,7 +2,6 @@
 using UnityEngine;
 using TMPro;
 using CountersPlus.Config;
-using System;
 
 namespace CountersPlus.Counters
 {
@@ -12,8 +11,7 @@ namespace CountersPlus.Counters
         internal TMP_Text RankText;
         internal TMP_Text PointsText;
         
-        private static ScoreConfigModel settings;
-
+        private ScoreConfigModel settings;
 
         GameObject _RankObject;
         int decimalPrecision;
@@ -98,46 +96,5 @@ namespace CountersPlus.Counters
             }
             GetComponent<ImmediateRankUIPanel>().Start(); //BS way of getting Harmony patch to function but "if it works its not stupid" ~Caeden117
         }
-        /*public void SetColor()
-        {
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "SS" | RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "SSS")
-            {
-                ColorUtility.TryParseHtmlString(settings.SSColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "S")
-            {
-                ColorUtility.TryParseHtmlString(settings.SColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "A")
-            {
-                ColorUtility.TryParseHtmlString(settings.AColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "B")
-            {
-                ColorUtility.TryParseHtmlString(settings.BColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "C")
-            {
-                ColorUtility.TryParseHtmlString(settings.CColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "D")
-            {
-                ColorUtility.TryParseHtmlString(settings.DColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            if (RankModel.GetRankName(relativeScoreAndImmediateRankCounter.immediateRank) == "E")
-            {
-                ColorUtility.TryParseHtmlString(settings.EColor, out Color RankColor);
-                RankText.color = RankColor;
-            }
-            else
-                RankText.color = Color.white;
-            
-        }*/
     }
 }

--- a/Counters+/Harmony/ScoreCounterHook.cs
+++ b/Counters+/Harmony/ScoreCounterHook.cs
@@ -7,6 +7,7 @@ using CountersPlus.Config;
 
 namespace CountersPlus.Harmony
 {
+
     [HarmonyPatch(typeof(ImmediateRankUIPanel))]
     [HarmonyPatch("Start", MethodType.Normal)]
     class ScoreCounterStartHook
@@ -26,6 +27,7 @@ namespace CountersPlus.Harmony
     class ScoreCounterRefreshUIHook
     {
         static ScoreConfigModel model = null;
+        
         static bool Prefix(ref ImmediateRankUIPanel __instance, ref RelativeScoreAndImmediateRankCounter ____relativeScoreAndImmediateRankCounter,
             ref RankModel.Rank ____prevImmediateRank, ref float ____prevRelativeScore, ref TextMeshProUGUI ____rankText,
             ref TextMeshProUGUI ____relativeScoreText)
@@ -37,6 +39,44 @@ namespace CountersPlus.Harmony
             {
                 ____rankText.text = model.Mode != ICounterMode.BaseGame ? $"\n{RankModel.GetRankName(rank)}" : RankModel.GetRankName(rank);
                 ____prevImmediateRank = rank;
+            }
+            if (model.CustomRankColors) //checks if custom rank colors is enabled
+            {
+                if (RankModel.GetRankName(rank) == "SS") 
+                {
+                    ColorUtility.TryParseHtmlString(model.SSColor, out Color RankColor); //converts config hex color to unity RGBA value
+                    ____rankText.color = RankColor; //sets color of ranktext
+                }
+                if (RankModel.GetRankName(rank) == "S")
+                {
+                    ColorUtility.TryParseHtmlString(model.SColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
+                if (RankModel.GetRankName(rank) == "A")
+                {
+                    ColorUtility.TryParseHtmlString(model.AColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
+                if (RankModel.GetRankName(rank) == "B")
+                {
+                    ColorUtility.TryParseHtmlString(model.BColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
+                if (RankModel.GetRankName(rank) == "C")
+                {
+                    ColorUtility.TryParseHtmlString(model.CColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
+                if (RankModel.GetRankName(rank) == "D")
+                {
+                    ColorUtility.TryParseHtmlString(model.DColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
+                if (RankModel.GetRankName(rank) == "E")
+                {
+                    ColorUtility.TryParseHtmlString(model.EColor, out Color RankColor);
+                    ____rankText.color = RankColor;
+                }
             }
             float score = ____relativeScoreAndImmediateRankCounter.relativeScore;
             if (Mathf.Abs(____prevRelativeScore - score) >= 0.001f)

--- a/Counters+/Harmony/ScoreCounterHook.cs
+++ b/Counters+/Harmony/ScoreCounterHook.cs
@@ -7,7 +7,6 @@ using CountersPlus.Config;
 
 namespace CountersPlus.Harmony
 {
-
     [HarmonyPatch(typeof(ImmediateRankUIPanel))]
     [HarmonyPatch("Start", MethodType.Normal)]
     class ScoreCounterStartHook
@@ -27,7 +26,6 @@ namespace CountersPlus.Harmony
     class ScoreCounterRefreshUIHook
     {
         static ScoreConfigModel model = null;
-        
         static bool Prefix(ref ImmediateRankUIPanel __instance, ref RelativeScoreAndImmediateRankCounter ____relativeScoreAndImmediateRankCounter,
             ref RankModel.Rank ____prevImmediateRank, ref float ____prevRelativeScore, ref TextMeshProUGUI ____rankText,
             ref TextMeshProUGUI ____relativeScoreText)

--- a/Counters+/UI/AdvancedCounterSettings.cs
+++ b/Counters+/UI/AdvancedCounterSettings.cs
@@ -100,6 +100,11 @@ namespace CountersPlus.UI
                 scorePrecision.GetTextForValue = (v) => Mathf.RoundToInt(v).ToString();
                 scorePrecision.GetValue = () => CC.settings.scoreConfig.DecimalPrecision;
                 scorePrecision.SetValue += (v) => CC.settings.scoreConfig.DecimalPrecision = Mathf.RoundToInt(v);
+
+                var customRankColors = CPEVC.AddList(ref sub, config, "Custom Rank Colors", "Allows the changing of each rank's color, to easily see what rank you are currently on in a song.\nColors can be in the config file.", 2);
+                customRankColors.GetTextForValue = (v) => (v != 0f) ? "ON" : "OFF";
+                customRankColors.GetValue = () => CC.settings.scoreConfig.CustomRankColors ? 1f : 0f;
+                customRankColors.SetValue += (v) => CC.settings.scoreConfig.CustomRankColors = v != 0f;
             } },
             { CC.settings.pbConfig, (sub, config) =>
             {

--- a/Counters+/UI/ViewControllers/ContributorsAndDonators.cs
+++ b/Counters+/UI/ViewControllers/ContributorsAndDonators.cs
@@ -24,6 +24,7 @@ namespace CountersPlus.UI.ViewControllers
             { "guyyst", "Cut's \"Separate Saber Counts\" option." },
             { "Steven", "Revitalized Custom Counters" },
             { "Pespiri", "Internal code refactoring" },
+            { "Alppuccino", "Custom Rank colors" }
         };
 
         internal static Dictionary<string, string> Donators = new Dictionary<string, string>()

--- a/Counters+/Utils/Config.cs
+++ b/Counters+/Utils/Config.cs
@@ -8,6 +8,7 @@ using IniParser.Model;
 using System.Linq;
 using CountersPlus.Utils;
 using IPA.Utilities;
+using UnityEngine;
 
 namespace CountersPlus.Config
 {
@@ -94,6 +95,7 @@ namespace CountersPlus.Config
                     input.SetPrivateField(info.Name, Enum.Parse(typeof(ICounterPositions), value));
                 else input.SetPrivateField(info.Name, Convert.ChangeType(value, finfo.FieldType));
                 if (finfo.GetValue(input) == null) throw new Exception();
+                
             }
             if (resetToDefaults)
             {
@@ -195,8 +197,16 @@ namespace CountersPlus.Config
         public ICounterMode Mode;
         public int DecimalPrecision;
         public bool DisplayRank;
+        public bool CustomRankColors;
+        public string SSColor;
+        public string SColor;
+        public string AColor;
+        public string BColor;
+        public string CColor;
+        public string DColor;
+        public string EColor;
     }
-
+    
     public sealed class PBConfigModel : ConfigModel{
         public PBConfigModel() { DisplayName = "Personal Best"; VersionAdded = new SemVer.Version("1.5.5"); }
         public int DecimalPrecision;

--- a/Counters+/Utils/Config.cs
+++ b/Counters+/Utils/Config.cs
@@ -8,7 +8,6 @@ using IniParser.Model;
 using System.Linq;
 using CountersPlus.Utils;
 using IPA.Utilities;
-using UnityEngine;
 
 namespace CountersPlus.Config
 {
@@ -95,7 +94,6 @@ namespace CountersPlus.Config
                     input.SetPrivateField(info.Name, Enum.Parse(typeof(ICounterPositions), value));
                 else input.SetPrivateField(info.Name, Convert.ChangeType(value, finfo.FieldType));
                 if (finfo.GetValue(input) == null) throw new Exception();
-                
             }
             if (resetToDefaults)
             {

--- a/Counters+/Utils/ConfigDefaults.cs
+++ b/Counters+/Utils/ConfigDefaults.cs
@@ -13,7 +13,7 @@ namespace CountersPlus.Config
             { "Missed", new MissedConfigModel(){ Enabled = true, Position = ICounterPositions.BelowCombo, Distance = 0, CustomMissTextIntegration = false } },
             { "Notes", new NoteConfigModel() { Enabled = false, Position = ICounterPositions.BelowCombo, Distance = 1, DecimalPrecision = 2, ShowPercentage = false} },
             { "Progress", new ProgressConfigModel() { Enabled = true, Position = ICounterPositions.BelowEnergy, Distance = 0, Mode = ICounterMode.Original, ProgressTimeLeft = false, IncludeRing = false } },
-            { "Score", new ScoreConfigModel() { Enabled = true, Position = ICounterPositions.BelowMultiplier, Distance = 0, DecimalPrecision = 2, DisplayRank = true, Mode = ICounterMode.Original } },
+            { "Score", new ScoreConfigModel() { Enabled = true, Position = ICounterPositions.BelowMultiplier, Distance = 0, DecimalPrecision = 2, DisplayRank = true, Mode = ICounterMode.Original, CustomRankColors = true, SSColor = "#00FFFF", SColor = "#FFFFFF", AColor = "#00FF00", BColor = "#FFFF00", CColor = "#FFA700", DColor = "#FF0000", EColor = "#FF0000" } },
             { "Speed", new SpeedConfigModel() { Enabled = false, Position = ICounterPositions.BelowMultiplier, Distance = 1, DecimalPrecision = 2, Mode = ICounterMode.Average } },
             { "Cut", new CutConfigModel() { Enabled = false, Position = ICounterPositions.AboveHighway, Distance = 0, SeparateSaberCounts = false} },
             { "Spinometer", new SpinometerConfigModel() { Enabled = false, Position = ICounterPositions.AboveMultiplier, Distance = 0, Mode = ICounterMode.Highest } },

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These are currently being moved over to the [Counters+ Wiki](https://github.com/
 |***Percentage Precision***|*Notes*, *Score*, *Speed*, and *Personal Best*|How precise do the decimals go?|
 |***Show Precentage***|*Notes*|Displays the percentage of notes hit over notes in total.|
 |***Display Rank***|*Score*|Displays the Rank you get during a song (SS, S, A, B, C, D, E.)|
+|***Custom Rank Colors***|*Score*|Changes color of the rank, depending on which rank you're at, according to the config.|
 |***Progress From End***|*Progress*|The counter starts at full, and decreases as you progress though a song.|
 |***Include Progress Ring***|*Progress*|Whether or not the *Progress From End* option will also effect the Progress Ring. Only available in *Original* mode.|
 |***Mode***|*Speed*, *Progress*, *Spinometer*, and *Score*|Changes the display mode for the Counter (See Hint Text in-game for more detail.)|


### PR DESCRIPTION
Added an option to the score counter which allows the user to customise certain colors of the rank text, if they choose to enable it in the settings. Comes with preset colors in the config.