### PR TITLE
Add option to display the three score values beforeCut, afterCut and cutDistance separately

### DIFF
--- a/Counters+/Counters/CutCounter.cs
+++ b/Counters+/Counters/CutCounter.cs
@@ -11,11 +11,12 @@ namespace CountersPlus.Counters
         private TMP_Text cutLabel;
         private BeatmapObjectSpawnController beatmapObjectSpawnController;
         private GameObject _RankObject;
-        private TMP_Text cutCounter;
+        private TMP_Text cutCounterLeft;
+        private TMP_Text cutCounterRight;
         private int totalCutCountLeft = 0;
         private int totalCutCountRight = 0;
-        private int totalScoreLeft = 0; // MaxScoreForNumberOfNotes() is an int. Don't expect scores over 2 billion.
-        private int totalScoreRight = 0;
+        private int[] totalScoresLeft = new int[] { 0, 0, 0 }; // [0]=beforeCut, [1]=afterCut, [2]=cutDistance
+        private int[] totalScoresRight = new int[] { 0, 0, 0 };
 
         private Dictionary<SaberSwingRatingCounter, NoteCutInfo> noteCutInfos = new Dictionary<SaberSwingRatingCounter, NoteCutInfo>();
 
@@ -33,12 +34,26 @@ namespace CountersPlus.Counters
 
             _RankObject = new GameObject("Counters+ | Cut Label");
             _RankObject.transform.parent = transform;
-            TextHelper.CreateText(out cutCounter, position - new Vector3(0, 0.4f, 0));
-            cutCounter.text = settings.SeparateSaberCounts ? "0  0" : "0";
-            cutCounter.fontSize = 4;
-            cutCounter.color = Color.white;
-            cutCounter.alignment = TextAlignmentOptions.Center;
-            
+            TextHelper.CreateText(out cutCounterLeft, position - new Vector3(0, settings.SeparateCutValues ? 0.9f : 0.4f, 0));
+            cutCounterLeft.fontSize = 4;
+            cutCounterLeft.color = Color.white;
+            cutCounterLeft.lineSpacing = -26;
+            cutCounterLeft.text = settings.SeparateCutValues ? "0\n0\n0" : "0";
+            cutCounterLeft.alignment = TextAlignmentOptions.Center;
+
+            if (settings.SeparateSaberCounts)
+            {
+                TextHelper.CreateText(out cutCounterRight, position - new Vector3(-0.2f, settings.SeparateCutValues ? 0.9f : 0.4f, 0));
+                cutCounterRight.fontSize = 4;
+                cutCounterRight.color = Color.white;
+                cutCounterRight.lineSpacing = -26;
+                cutCounterRight.text = settings.SeparateCutValues ? "0\n0\n0" : "0";
+                cutCounterRight.alignment = TextAlignmentOptions.Left;
+
+                cutCounterLeft.alignment = TextAlignmentOptions.Right;
+                cutCounterLeft.transform.position = position - new Vector3(0.2f, settings.SeparateCutValues ? 0.9f : 0.4f, 0);
+            }
+
             if (beatmapObjectSpawnController != null)
                 beatmapObjectSpawnController.noteWasCutEvent += UpdateScore;
         }
@@ -62,28 +77,66 @@ namespace CountersPlus.Counters
             //"cutDistanceRawScore" is already calculated into "beforeCutRawScore"
             if (noteCutInfos[v].saberType == Saber.SaberType.SaberA)
             {
-                totalScoreLeft += beforeCut + afterCut + cutDistance;
+                totalScoresLeft[0] += beforeCut;
+                totalScoresLeft[1] += afterCut;
+                totalScoresLeft[2] += cutDistance;
                 ++totalCutCountLeft;
             }
             else
             {
-                totalScoreRight += beforeCut + afterCut + cutDistance;
+                totalScoresRight[0] += beforeCut;
+                totalScoresRight[1] += afterCut;
+                totalScoresRight[2] += cutDistance;
                 ++totalCutCountRight;
             }
 
-            if (settings.SeparateSaberCounts)
-            {
-                double leftAverage = Math.Round(((double)(totalScoreLeft)) / (totalCutCountLeft));
-                double rightAverage = Math.Round(((double)(totalScoreRight)) / (totalCutCountRight));
-                leftAverage = Double.IsNaN(leftAverage) ? 0 : leftAverage;
-                rightAverage = Double.IsNaN(rightAverage) ? 0 : rightAverage;
-                cutCounter.text = $"{leftAverage}";
-                cutCounter.text += $"  {rightAverage}";
-            }
-            else
-                cutCounter.text = $"{Math.Round(((double)(totalScoreRight + totalScoreLeft)) / (totalCutCountRight + totalCutCountLeft))}";
+            UpdateLabels();
 
             noteCutInfos.Remove(v);
+        }
+
+        private void UpdateLabels()
+        {
+            double[] leftAverages = new double[3]
+            {
+                SafeDivideScore(totalScoresLeft[0], totalCutCountLeft),
+                SafeDivideScore(totalScoresLeft[1], totalCutCountLeft),
+                SafeDivideScore(totalScoresLeft[2], totalCutCountLeft)
+            };
+
+            double[] rightAverages = new double[3]
+            {
+                SafeDivideScore(totalScoresRight[0], (totalCutCountRight)),
+                SafeDivideScore(totalScoresRight[1], (totalCutCountRight)),
+                SafeDivideScore(totalScoresRight[2], (totalCutCountRight))
+            };
+
+            if (settings.SeparateCutValues && settings.SeparateSaberCounts)
+            {
+                cutCounterLeft.text = $"{leftAverages[0]}\n{leftAverages[1]}\n{leftAverages[2]}";
+                cutCounterRight.text = $"{rightAverages[0]}\n{rightAverages[1]}\n{rightAverages[2]}";
+            }
+            else if (settings.SeparateCutValues)
+            {
+                cutCounterLeft.text = $"{(leftAverages[0] + rightAverages[0]) / 2}\n{(leftAverages[1] + rightAverages[1]) / 2}\n{(leftAverages[2] + rightAverages[2]) / 2}";
+            }
+            else if (settings.SeparateSaberCounts)
+            {
+                cutCounterLeft.text = $"{leftAverages[0] + leftAverages[1] + leftAverages[2]}";
+                cutCounterRight.text = $"{rightAverages[0] + rightAverages[1] + rightAverages[2]}";
+            }
+            else
+            {
+                // Divide combined left and right score by 2 only if both sabers have cut something.
+                int divisor = (totalCutCountRight * totalCutCountLeft == 0 ? 1 : 2);
+                cutCounterLeft.text = $"{(leftAverages[0] + leftAverages[1] + leftAverages[2] + rightAverages[0] + rightAverages[1] + rightAverages[2]) / divisor}";
+            }
+        }
+
+        private double SafeDivideScore(int total, int count)
+        {
+            double result = Math.Round(((double)(total)) / (count));
+            return Double.IsNaN(result) ? 0 : result;
         }
     }
 }

--- a/Counters+/UI/BSML/Config/Cut.bsml
+++ b/Counters+/UI/BSML/Config/Cut.bsml
@@ -1,5 +1,8 @@
 ﻿<vertical spacing='1'>
   <horizontal horizontal-fit='PreferredSize'>
-    <checkbox-setting text='Separate Saber Cuts' on-change='update_model' apply-on-change='true' value='separate' hover-hint='Shows the average cut for the left and right sabers separately.'></checkbox-setting>
+    <checkbox-setting text='Separate Saber Cuts' on-change='update_model' apply-on-change='true' value='separate-sabers' hover-hint='Shows the average cut for the left and right sabers separately.'></checkbox-setting>
+  </horizontal>
+  <horizontal horizontal-fit='PreferredSize'>
+    <checkbox-setting text='Separate Cut Values' on-change='update_model' apply-on-change='true' value='separate-values' hover-hint='Show separate averages for angle before cut (0-70), angle after cut (0-30) and distance to center (0-15).'></checkbox-setting>
   </horizontal>
 </vertical>

--- a/Counters+/UI/ViewControllers/ConfigModelControllers/CutController.cs
+++ b/Counters+/UI/ViewControllers/ConfigModelControllers/CutController.cs
@@ -13,11 +13,18 @@ namespace CountersPlus.UI.ViewControllers.ConfigModelControllers
     {
         public ConfigModelController parentController;
 
-        [UIValue("separate")]
+        [UIValue("separate-sabers")]
         public bool SeparateSaberCuts
         {
             get => (parentController?.ConfigModel as CutConfigModel).SeparateSaberCounts;
             set => (parentController?.ConfigModel as CutConfigModel).SeparateSaberCounts = value;
+        }
+
+        [UIValue("separate-values")]
+        public bool SeparateCutValues
+        {
+            get => (parentController?.ConfigModel as CutConfigModel).SeparateCutValues;
+            set => (parentController?.ConfigModel as CutConfigModel).SeparateCutValues = value;
         }
 
         [UIAction("update_model")]

--- a/Counters+/Utils/Config.cs
+++ b/Counters+/Utils/Config.cs
@@ -256,6 +256,7 @@ namespace CountersPlus.Config
         public CutConfigModel() { DisplayName = "Cut"; VersionAdded = new SemVer.Version("1.1.0");
             Enabled = false; Position = ICounterPositions.AboveHighway; Distance = 1; } //Default values
         public bool SeparateSaberCounts = false;
+        public bool SeparateCutValues = false;
     }
 
     public sealed class NotesLeftConfigModel : ConfigModel


### PR DESCRIPTION
Been getting average cuts of around 103 on my left, and 108 on my right saber, so to figure out why my left is worse I added this option.

![15-02-20__20-07-11](https://user-images.githubusercontent.com/19490555/74593747-eb065580-502e-11ea-8734-877405c3a66c.jpg)

I thought about adding labels to make it more clear what number represents what, but that ended up looking way too crowded, plus I figured anybody who bothers enabling this option will read the description and get the order from there.

The new way of adding options is much nicer btw^^