### PR TITLE
Persistent Singletons WeirdChamp

### DIFF
--- a/Counters+/UI/MenuButtonManager.cs
+++ b/Counters+/UI/MenuButtonManager.cs
@@ -27,7 +27,7 @@ namespace CountersPlus.UI
 
         public void Dispose()
         {
-            if (MenuButtons.IsSingletonAvailable)
+            if (MenuButtons.IsSingletonAvailable && BSMLParser.IsSingletonAvailable)
             {
                 MenuButtons.instance.UnregisterButton(menuButton);
             }


### PR DESCRIPTION
sometimes the parser is destroyed before the menu buttons and the unregister button calls the parser so this might throw an error. very low priority just putting it here just cause. persistent singleton are weirdchamp