### PR TITLE
Note counter percentage

### DIFF
--- a/Counters+/Counters/NotesCounter.cs
+++ b/Counters+/Counters/NotesCounter.cs
@@ -34,7 +34,7 @@ namespace CountersPlus.Counters
             counter.text = $"{goodCuts} / {allCuts}";
             if (Settings.ShowPercentage)
             {
-                float percentage = (float)goodCuts / allCuts;
+                float percentage = (float)goodCuts / allCuts * 100.0;
                 counter.text += $" - {percentage.ToString($"F{Settings.DecimalPrecision}")}%";
             }
         }


### PR DESCRIPTION
`percentage` is scaled from 0-1 to 0-100. This fixes the display of percentages from (for example) `495 / 500 - 0.99%` to `495 / 500 - 99.00%` as it should be.