### PR TITLE
Fix custom Counters+ counter conflicts when registering settings into Heck

### DIFF
--- a/Counters+/ConfigModels/SettableSettings/CountersPlusSettableSettings.cs
+++ b/Counters+/ConfigModels/SettableSettings/CountersPlusSettableSettings.cs
@@ -32,10 +32,10 @@ namespace CountersPlus.ConfigModels.SettableSettings
             // (All counter config models, plus main settings and main canvas)
             // and ensure only one of each is in the collection
             var configurableObjects = configs
+                .DistinctBy(x => x.DisplayName) // DistinctBy LINQ method might not be needed, zenject supposedly doesn't return duplicate objects but it currently acts as a safe-guard.
                 .Cast<object>()
                 .Append(mainConfigModel)
-                .Append(hudConfig.MainCanvasSettings)
-                .DistinctBy(x => x.GetType());
+                .Append(hudConfig.MainCanvasSettings);
 
             // Caching these before the loop
             var settableSettingType = typeof(CountersPlusWrapperSetting);

--- a/Counters+/Installers/CoreInstaller.cs
+++ b/Counters+/Installers/CoreInstaller.cs
@@ -37,6 +37,8 @@ namespace CountersPlus.Installers
                     config = customCounter.ConfigDefaults;
                     mainConfig.CustomCounters.Add(customCounter.Name, config);
                 }
+
+                config.DisplayName = customCounter.Name;
                 config.AttachedCustomCounter = customCounter;
                 customCounter.Config = config;
                 BindCustomCounter(customCounter, config);

--- a/Counters+/Installers/CountersInstaller.cs
+++ b/Counters+/Installers/CountersInstaller.cs
@@ -57,7 +57,7 @@ namespace CountersPlus.Installers
                 ScoreConfigModel scoreConfig = Container.Resolve<ScoreConfigModel>();
                 HUDCanvas canvasSettings = GrabCanvasForCounter(scoreConfig);
                 return scoreConfig.Enabled && settings.UnderScore && (dataModel.playerData.playerSpecificSettings.noTextsAndHuds ? canvasSettings.IgnoreNoTextAndHUDOption : true);
-                });
+            });
 
             foreach (Custom.CustomCounter customCounter in Plugin.LoadedCustomCounters.Values)
             {


### PR DESCRIPTION
The internal configs for custom counters were all using the default value of "Unknown" for the `DisplayName` property.
However , this will result in conflicts when Heck and multiple custom counters are installed. When registering the settings into Heck, we end up with settings collisions due to the custom counters sharing the same internal config model (and thus the same properties) as well as the `DisplayName`.

The problem is thus solved by explicitly setting the DisplayName for custom counters when creating the config.

Issue was discovered by @ChirpyMisha 🙂 