### PR TITLE
Missed notes counter only after first miss

### DIFF
--- a/Counters+/ConfigModels/Counters/MissedConfigModel.cs
+++ b/Counters+/ConfigModels/Counters/MissedConfigModel.cs
@@ -16,6 +16,9 @@ namespace CountersPlus.ConfigModels
         [UIValue(nameof(CountBadCuts))]
         public virtual bool CountBadCuts { get; set; } = true;
         
+        [UIValue(nameof(CountChainNoteMisses))]
+        public virtual bool CountChainNoteMisses { get; set; } = false;
+        
         [UIValue(nameof(HideWhenNone))]
         public virtual bool HideWhenNone { get; set; } = true;
     }

--- a/Counters+/ConfigModels/Counters/MissedConfigModel.cs
+++ b/Counters+/ConfigModels/Counters/MissedConfigModel.cs
@@ -15,5 +15,8 @@ namespace CountersPlus.ConfigModels
 
         [UIValue(nameof(CountBadCuts))]
         public virtual bool CountBadCuts { get; set; } = true;
+        
+        [UIValue(nameof(HideWhenNone))]
+        public virtual bool HideWhenNone { get; set; } = true;
     }
 }

--- a/Counters+/Counters/MissedCounter.cs
+++ b/Counters+/Counters/MissedCounter.cs
@@ -12,16 +12,36 @@ namespace CountersPlus.Counters
         public override void CounterInit()
         {
             GenerateBasicText("Misses", out counter);
+
+            if (Settings.HideWhenNone)
+                counter.gameObject.SetActive(false);
         }
 
         public void OnNoteCut(NoteData data, NoteCutInfo info)
         {
-            if (Settings.CountBadCuts && !info.allIsOK && data.colorType != ColorType.None) counter.text = (++notesMissed).ToString();
+            if (Settings.CountBadCuts && !info.allIsOK && data.colorType != ColorType.None)
+            {
+                UpdateMissCount();
+            }
         }
 
         public void OnNoteMiss(NoteData data)
         {
-            if (data.colorType != ColorType.None && data.gameplayType != NoteData.GameplayType.BurstSliderElement) counter.text = (++notesMissed).ToString();
+            if (data.colorType != ColorType.None && data.gameplayType != NoteData.GameplayType.BurstSliderElement)
+            {
+                UpdateMissCount();
+            }
+        }
+
+        private void UpdateMissCount()
+        {
+            notesMissed++;
+            counter.text = notesMissed.ToString();
+
+            if (Settings.HideWhenNone && !counter.gameObject.activeSelf)
+            {
+                counter.gameObject.SetActive(true);
+            }
         }
     }
 }

--- a/Counters+/Counters/MissedCounter.cs
+++ b/Counters+/Counters/MissedCounter.cs
@@ -33,7 +33,7 @@ namespace CountersPlus.Counters
 
         public void OnNoteMiss(NoteData data)
         {
-            if (data.colorType != ColorType.None && data.gameplayType != NoteData.GameplayType.BurstSliderElement)
+            if (data.colorType != ColorType.None && (Settings.CountChainNoteMisses || data.gameplayType != NoteData.GameplayType.BurstSliderElement))
             {
                 UpdateMissCount();
             }

--- a/Counters+/Counters/MissedCounter.cs
+++ b/Counters+/Counters/MissedCounter.cs
@@ -8,14 +8,18 @@ namespace CountersPlus.Counters
     {
         private int notesMissed = 0;
         private TMP_Text counter;
+        private TMP_Text label;
 
         public override void CounterInit()
         {
             GenerateBasicText("Misses", out counter);
+            label = counter.transform.parent.GetComponentInChildren<TMP_Text>(true);
+            if (label == counter) label = null;
             
             if (Settings.HideWhenNone && counter != null)
             {
-                counter.transform.parent.gameObject.SetActive(false);
+                counter.enabled = false;
+                if (label != null) label.enabled = false;
             }
         }
 
@@ -40,9 +44,10 @@ namespace CountersPlus.Counters
             notesMissed++;
             counter.text = notesMissed.ToString();
 
-            if (Settings.HideWhenNone && !counter.transform.parent.gameObject.activeSelf)
+            if (Settings.HideWhenNone)
             {
-                counter.transform.parent.gameObject.SetActive(true);
+                if (!counter.enabled) counter.enabled = true;
+                if (label != null && !label.enabled) label.enabled = true;
             }
         }
     }

--- a/Counters+/Counters/MissedCounter.cs
+++ b/Counters+/Counters/MissedCounter.cs
@@ -12,9 +12,11 @@ namespace CountersPlus.Counters
         public override void CounterInit()
         {
             GenerateBasicText("Misses", out counter);
-
-            if (Settings.HideWhenNone)
-                counter.gameObject.SetActive(false);
+            
+            if (Settings.HideWhenNone && counter != null)
+            {
+                counter.transform.parent.gameObject.SetActive(false);
+            }
         }
 
         public void OnNoteCut(NoteData data, NoteCutInfo info)
@@ -38,9 +40,9 @@ namespace CountersPlus.Counters
             notesMissed++;
             counter.text = notesMissed.ToString();
 
-            if (Settings.HideWhenNone && !counter.gameObject.activeSelf)
+            if (Settings.HideWhenNone && !counter.transform.parent.gameObject.activeSelf)
             {
-                counter.gameObject.SetActive(true);
+                counter.transform.parent.gameObject.SetActive(true);
             }
         }
     }

--- a/Counters+/UI/BSML/Config/Missed.bsml
+++ b/Counters+/UI/BSML/Config/Missed.bsml
@@ -1,3 +1,4 @@
 ﻿<vertical spacing='1' horizontal-fit='PreferredSize'>
   <checkbox-setting text='Include Bad Cuts' apply-on-change='true' value='CountBadCuts' hover-hint='Bad cuts count towards the Missed counter.'/>
+  <checkbox-setting text='Hidden Until First Miss' apply-on-change='true' value='HideWhenNone' hover-hint='Hide the counter until you have one miss'/>
 </vertical>

--- a/Counters+/UI/BSML/Config/Missed.bsml
+++ b/Counters+/UI/BSML/Config/Missed.bsml
@@ -1,4 +1,5 @@
 ﻿<vertical spacing='1' horizontal-fit='PreferredSize'>
   <checkbox-setting text='Include Bad Cuts' apply-on-change='true' value='CountBadCuts' hover-hint='Bad cuts count towards the Missed counter.'/>
   <checkbox-setting text='Hidden Until First Miss' apply-on-change='true' value='HideWhenNone' hover-hint='Hide the counter until you have one miss'/>
+  <checkbox-setting text='Count Chain Links' apply-on-change='true' value='CountChainNoteMisses' hover-hint='Chain links count towards the Missed counter.'/>
 </vertical>


### PR DESCRIPTION
I just added another toggle so that the missed notes counter will only show after you have actually missed a note

![image](https://github.com/user-attachments/assets/dbacd48e-c4cc-4b0d-a71c-75127b2e3d27)
